### PR TITLE
dep: update to newest version of `async-usercalls`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,11 +63,8 @@ wasi = "0.11.0"
 libc = "0.2.149"
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
-async-usercalls = "0.5"
+async-usercalls = "0.6"
 crossbeam-channel = "0.5"
-
-[patch.crates-io]
-async-usercalls = { git = "https://github.com/fortanix/rust-sgx.git", branch = "master" }
 
 [dev-dependencies]
 env_logger = { version = "0.9.3", default-features = false }


### PR DESCRIPTION
get rid of `patch` section and use normal versioning, since this dependency is publicly available